### PR TITLE
Made sure to store \0

### DIFF
--- a/string/string_copy.s
+++ b/string/string_copy.s
@@ -26,11 +26,11 @@ char   .req R2   @
 
 loop:
 	ldrb	char,[string],#1
+	strb	char,[newStr],#1
 	
 	cmp	char,#0
 	beq	return			@if(char == \0) return
 	
-	strb	char,[newStr],#1
 	b	loop
 
 return:


### PR DESCRIPTION
``string_copy`` assumed the allocated memory was zeroed out. Now, we store the ``\0`` to indicate that the string has ended.